### PR TITLE
Trigger CI pipeline when pushing commits to an open PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,11 @@
 name: Codecov
+
 on:
   push:
-    branches: [ "*" ]
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+coverage
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
Currently, the CI pipeline is only triggered when merging PRs or pushing code directly to the branches. The added property now enables the pipeline to run on commits pushed to an open PR.