### PR TITLE
feat: checkbox styles improvement

### DIFF
--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -21,10 +21,10 @@ const checkboxVariants = cva(
 )
 
 export interface CheckboxProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>, 'checked'> {
+  extends Omit<React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>, 'checked'>,
+  VariantProps<typeof checkboxVariants> {
   checked?: boolean;
   indeterminate?: boolean;
-  size?: "sm" | "md";
 }
 
 const Checkbox = React.forwardRef<
@@ -37,18 +37,13 @@ const Checkbox = React.forwardRef<
     disabled={disabled}
     className={cn(
       checkboxVariants({ size, className }),
-      // Default/Unchecked state
       "bg-elevation-200 border-divider-75",
-      // Hover state for unchecked
       "enabled:hover:bg-elevation-250 enabled:hover:border-divider-75",
-      // Checked/Indeterminate state
       "data-[state=checked]:bg-brand-50 data-[state=checked]:border-brand-200",
       "data-[state=indeterminate]:bg-brand-50 data-[state=indeterminate]:border-brand-200",
-      // Hover state for checked/indeterminate
       "enabled:data-[state=checked]:hover:bg-brand-100 enabled:data-[state=checked]:hover:border-brand-200",
       "enabled:data-[state=indeterminate]:hover:bg-brand-100 enabled:data-[state=indeterminate]:hover:border-brand-200",
-      // Disabled state
-      "disabled:!bg-[#D1CCC1] disabled:!border-0 disabled:cursor-not-allowed"
+      "disabled:!bg-elevation-300 disabled:!border-0 disabled:cursor-not-allowed"
     )}
     {...props}
   >

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,25 +1,68 @@
 import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
-import { Check } from "lucide-react"
+import { Check, Minus } from "lucide-react"
+import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
+const checkboxVariants = cva(
+  "peer shrink-0 rounded-md border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+  {
+    variants: {
+      size: {
+        sm: "h-4 w-4",
+        md: "h-5 w-5",
+      }
+    },
+    defaultVariants: {
+      size: "md",
+    },
+  }
+)
+
+export interface CheckboxProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>, 'checked'> {
+  checked?: boolean;
+  indeterminate?: boolean;
+  size?: "sm" | "md";
+}
+
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
->(({ className, ...props }, ref) => (
+  CheckboxProps
+>(({ className, size, checked, indeterminate, disabled, ...props }, ref) => (
   <CheckboxPrimitive.Root
     ref={ref}
+    checked={checked}
+    disabled={disabled}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
-      className
+      checkboxVariants({ size, className }),
+      // Default/Unchecked state
+      "bg-elevation-200 border-divider-75",
+      // Hover state for unchecked
+      "enabled:hover:bg-elevation-250 enabled:hover:border-divider-75",
+      // Checked/Indeterminate state
+      "data-[state=checked]:bg-brand-50 data-[state=checked]:border-brand-200",
+      "data-[state=indeterminate]:bg-brand-50 data-[state=indeterminate]:border-brand-200",
+      // Hover state for checked/indeterminate
+      "enabled:data-[state=checked]:hover:bg-brand-100 enabled:data-[state=checked]:hover:border-brand-200",
+      "enabled:data-[state=indeterminate]:hover:bg-brand-100 enabled:data-[state=indeterminate]:hover:border-brand-200",
+      // Disabled state
+      "disabled:!bg-[#D1CCC1] disabled:!border-0 disabled:cursor-not-allowed"
     )}
     {...props}
   >
     <CheckboxPrimitive.Indicator
-      className={cn("flex items-center justify-center text-current")}
+      className={cn(
+        "flex items-center justify-center",
+        disabled ? "text-white" : "text-brand-200"
+      )}
     >
-      <Check className="h-4 w-4" />
+      {indeterminate ? (
+        <Minus className="h-3 w-3" />
+      ) : (
+        <Check className="h-3 w-3" />
+      )}
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ))

--- a/src/pages/onboarding/ProfileInfo.tsx
+++ b/src/pages/onboarding/ProfileInfo.tsx
@@ -7,6 +7,7 @@ import { copyToClipboard } from "@/utils";
 
 export default function ProfileInfo() {
   const [isPrivateKeyVisible, setIsPrivateKeyVisible] = useState(false);
+  const [isChecked, setIsChecked] = useState(false);
 
   const togglePrivateKeyVisibility = () =>
     setIsPrivateKeyVisible((prev) => !prev);
@@ -75,7 +76,14 @@ export default function ProfileInfo() {
         </div>
 
         <div className="flex items-center space-x-2">
-          <Checkbox id="backup" className="bg-transparent border-[#18181B]" />
+          <Checkbox
+            id="backup"
+            checked={isChecked}
+            // indeterminate={true}
+            onCheckedChange={(checked) => setIsChecked(checked as boolean)}
+            // disabled={true}
+            size="sm"
+          />
           <label
             htmlFor="backup"
             className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"


### PR DESCRIPTION
Fixes #50

Screenshots/Video:

https://github.com/user-attachments/assets/2e08432e-178a-4d75-9323-1ed7ccfc521f



Improvements:
- [x] The component styling must match all the states specified in the design specs: default, hover and disabled
- [x] The component must have two different sizes, as per the design specs: small (sm) and medium (md)
- [x] There has to be a property to set the checkbox state (checked or unchecked)
- [x] There has to be a property to set the checkbox size (sm or md)
- [x] There has to be a property to turn the checkbox into the disabled state
