### PR TITLE
fix(i18n): initialize locale

### DIFF
--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -1,8 +1,10 @@
 import { IntlProvider } from "react-intl";
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useState } from "react";
 import { detectBrowserLanguage } from "@/utils";
 
 import en from "@/i18n/en.json";
+
+const DEFAULT_LOCALE = "en";
 
 const translations: { [key: string]: typeof en } = {
   en,
@@ -14,7 +16,7 @@ type LanguageContextType = {
 };
 
 const LanguageContext = createContext<LanguageContextType>({
-  locale: "en",
+  locale: DEFAULT_LOCALE,
   setLocale: () => {},
 });
 
@@ -25,16 +27,12 @@ export default function LanguageProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [locale, setLocale] = useState("");
-
-  useEffect(() => {
-    setLocale(detectBrowserLanguage());
-  }, []);
+  const [locale, setLocale] = useState(detectBrowserLanguage());
 
   return (
     <LanguageContext.Provider value={{ locale, setLocale }}>
       <IntlProvider
-        defaultLocale="en"
+        defaultLocale={DEFAULT_LOCALE}
         locale={locale}
         messages={translations[locale]}
       >


### PR DESCRIPTION
Initialize locale immediately instead of waiting for `useEffect` hook.

This prevents the following error logged to console:
```
Error: [@formatjs/intl Error INVALID_CONFIG] "locale" was not configured, using "en" as fallback. See https://formatjs.github.io/docs/react-intl/api#intlshape for more details
```