### PR TITLE
chore(dev): prepare router v7 upgrade

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -121,13 +121,26 @@ const router = createBrowserRouter([
     path: routes.PREVIEW_BILL,
     element: <PreviewBill />,
   },
-]);
+], {
+  future: {
+    v7_fetcherPersist: true,
+    v7_normalizeFormMethod: true,
+    v7_partialHydration: true,
+    v7_relativeSplatPath: true,
+    v7_skipActionErrorRevalidation: true,
+  }
+});
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <LanguageProvider>
       <DefaultLayout>
-        <RouterProvider router={router} />
+        <RouterProvider
+          router={router}
+          future={{
+            v7_startTransition: true
+          }}
+        />
       </DefaultLayout>
     </LanguageProvider>
   </StrictMode>


### PR DESCRIPTION
Opt into future behavior of react-router: https://reactrouter.com/en/6.28.0/upgrading/future

This prepares upgrading to v7 and as a side effect does away the distracting console warnings, e.g.
```
React Router Future Flag Warning: React Router will begin wrapping state updates in `React.startTransition` in v7. You can use the `v7_startTransition` future flag to opt-in early. For more information, see https://reactrouter.com/v6/upgrading/future#v7_starttransition.
```