### PR TITLE
ui(i18n): format numbers on Bills page

### DIFF
--- a/src/components/FormattedCurrency.test.tsx
+++ b/src/components/FormattedCurrency.test.tsx
@@ -102,8 +102,8 @@ describe("FormattedCurrency", () => {
     });
     it("should verify bitcoin sign can be disabled", () => {
       const { container } = render({ value: 21, currency: "BTC" });
-      expect(container.firstElementChild!.textContent).toBe("+BTC 21.00")
-      // TODO: should be `expect(container.firstElementChild!.textContent).toBe("+₿21.00")`
+      expect(container.firstElementChild!.textContent).toBe("+BTC 21.00000000")
+      // TODO: should be `expect(container.firstElementChild!.textContent).toBe("+₿21.00000000")`
     });
   });
 

--- a/src/components/FormattedCurrency.test.tsx
+++ b/src/components/FormattedCurrency.test.tsx
@@ -80,30 +80,57 @@ describe("FormattedCurrency", () => {
   });
 
   describe("currency", () => {
-    it("should verify dollar sign can be disabled", () => {
+    it("should verify dollar sign", () => {
       const { container } = render({ value: 21, currency: "USD" });
       expect(container.firstElementChild!.textContent).toBe("+$21.00");
     });
-    it("should verify dollar sign can be disabled (es)", () => {
+    it("should verify dollar sign (es)", () => {
       const { container } = render({ value: 21, currency: "USD", locale: "es" });
       expect(container.firstElementChild!.textContent).toBe("+21,00 US$");
     });
-    it("should verify euro sign can be disabled (fr)", () => {
+    it("should verify euro sign (fr)", () => {
       const { container } = render({ value: 21, currency: "EUR", locale: "fr" });
       expect(container.firstElementChild!.textContent).toBe("+21,00 €");
     });
-    it("should verify euro sign can be disabled (zh)", () => {
+    it("should verify euro sign (zh)", () => {
       const { container } = render({ value: 21, currency: "EUR", locale: "zh"});
       expect(container.firstElementChild!.textContent).toBe("+€21.00");
     });
-    it("should verify euro sign can be disabled (pt)", () => {
+    it("should verify euro sign (pt)", () => {
       const { container } = render({ value: 21, currency: "EUR", locale: "pt"});
       expect(container.firstElementChild!.textContent).toBe("+€ 21,00");
     });
-    it("should verify bitcoin sign can be disabled", () => {
+    it("should verify bitcoin sign", () => {
       const { container } = render({ value: 21, currency: "BTC" });
+      expect(container.firstElementChild!.textContent).toBe("+₿ 21.00000000")
+    });
+    it("should verify bitcoin sign (es)", () => {
+      const { container } = render({ value: 21, currency: "BTC", locale: "es" });
+      expect(container.firstElementChild!.textContent).toBe("+21,00000000 ₿")
+    });
+    it("should verify bitcoin sign (pt)", () => {
+      const { container } = render({ value: 21, currency: "BTC", locale: "pt" });
+      expect(container.firstElementChild!.textContent).toBe("+₿ 21,00000000")
+    });
+    it("should verify bitcoin code", () => {
+      const { container } = render({ value: 21, currency: "BTC", currencyDisplay: "code" });
       expect(container.firstElementChild!.textContent).toBe("+BTC 21.00000000")
-      // TODO: should be `expect(container.firstElementChild!.textContent).toBe("+₿21.00000000")`
+    });
+    it("should verify bitcoin name", () => {
+      const { container } = render({ value: 21, currency: "BTC", currencyDisplay: "name" });
+      expect(container.firstElementChild!.textContent).toBe("+21.00000000 bitcoin")
+    });
+    it("should verify dollar code", () => {
+      const { container } = render({ value: 21, currency: "USD", currencyDisplay: "code" });
+      expect(container.firstElementChild!.textContent).toBe("+USD 21.00")
+    });
+    it("should verify dollar name", () => {
+      const { container } = render({ value: 21, currency: "USD", currencyDisplay: "name" });
+      expect(container.firstElementChild!.textContent).toBe("+21.00 US dollars")
+    });
+    it("should verify dollar name (es)", () => {
+      const { container } = render({ value: 21, currency: "USD", currencyDisplay: "name", locale: "es" });
+      expect(container.firstElementChild!.textContent).toBe("+21,00 dólares estadounidenses")
     });
   });
 

--- a/src/components/FormattedCurrency.test.tsx
+++ b/src/components/FormattedCurrency.test.tsx
@@ -1,7 +1,7 @@
 import { render as reactRender, cleanup} from "@testing-library/react";
 import { describe, it, expect, afterEach } from "vitest";
-import { FormattedCurrency, type FormattedCurrencyProps } from "./FormattedCurrency";
 import { IntlProvider } from "react-intl";
+import { FormattedCurrency, type FormattedCurrencyProps } from "./FormattedCurrency";
 
 describe("FormattedCurrency", () => {
 
@@ -17,8 +17,6 @@ describe("FormattedCurrency", () => {
     it("en", () => {
       const { container } = render({ value: 0 })
       expect(container.firstElementChild!.textContent).toBe("0.00");
-      expect(container.firstElementChild!.classList).not.toContain("text-signal-success");
-      expect(container.firstElementChild!.classList).not.toContain("text-signal-error");
     });
 
     it("es", () => {
@@ -41,8 +39,6 @@ describe("FormattedCurrency", () => {
     it("en", () => {
       const { container } = render({ value: 21000001.23456789 });
       expect(container.firstElementChild!.textContent).toBe("+21,000,001.23456789");
-      expect(container.firstElementChild!.classList).toContain("text-signal-success");
-      expect(container.firstElementChild!.classList).not.toContain("text-signal-error");
     });
 
     it("es", () => {
@@ -65,8 +61,6 @@ describe("FormattedCurrency", () => {
     it("en", () => {
       const { container } = render({ value: -1337.42 });
       expect(container.firstElementChild!.textContent).toBe("-1,337.42");
-      expect(container.firstElementChild!.classList).not.toContain("text-signal-success");
-      expect(container.firstElementChild!.classList).toContain("text-signal-error");
     });
 
     it("es", () => {
@@ -82,6 +76,45 @@ describe("FormattedCurrency", () => {
     it("zh", () => {
       const { container } = render({ value: -1337.42, locale: "zh" });
       expect(container.firstElementChild!.textContent).toBe("-1,337.42");
+    });
+  });
+
+  describe("font color", () => {
+    it("should verify zero value color", () => {
+      const { container } = render({ value: 0 });
+      expect(container.firstElementChild!.classList).not.toContain("text-signal-success");
+      expect(container.firstElementChild!.classList).not.toContain("text-signal-error");
+    });
+
+    it("should verify positive value color", () => {
+      const { container } = render({ value: 21 });
+      expect(container.firstElementChild!.classList).toContain("text-signal-success");
+      expect(container.firstElementChild!.classList).not.toContain("text-signal-error");
+    });
+
+    it("should verify negative value color", () => {
+      const { container } = render({ value: -21 });
+      expect(container.firstElementChild!.classList).not.toContain("text-signal-success");
+      expect(container.firstElementChild!.classList).toContain("text-signal-error");
+    });
+
+    it("should verify disabling font color", () => {
+      const { container } = render({ value: -21, color: "none" });
+      expect(container.firstElementChild!.classList).not.toContain("text-signal-success");
+      expect(container.firstElementChild!.classList).not.toContain("text-signal-error");
+    });
+
+    it("should verify adapting font color", () => {
+      const { container } = render({ value: 21, color: "red" });
+      expect(container.firstElementChild!.classList).not.toContain("text-signal-success");
+      expect(container.firstElementChild!.classList).toContain("text-signal-error");
+    });
+
+    it("should verify customizing font color", () => {
+      const { container } = render({ value: 21, color: "none", className: "text-text-300" });
+      expect(container.firstElementChild!.classList).not.toContain("text-signal-success");
+      expect(container.firstElementChild!.classList).not.toContain("text-signal-error");
+      expect(container.firstElementChild!.classList).toContain("text-text-300");
     });
   });
 });

--- a/src/components/FormattedCurrency.test.tsx
+++ b/src/components/FormattedCurrency.test.tsx
@@ -1,0 +1,87 @@
+import { render as reactRender, cleanup} from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import { FormattedCurrency, type FormattedCurrencyProps } from "./FormattedCurrency";
+import { IntlProvider } from "react-intl";
+
+describe("FormattedCurrency", () => {
+
+  afterEach(cleanup);
+
+  const render = ({locale = "en", ...props}: FormattedCurrencyProps & { locale?: string }) => reactRender(
+    <IntlProvider locale={locale}>
+      <FormattedCurrency {...props} />
+    </IntlProvider>
+  );
+
+  describe("should display zero value correctly", () => {
+    it("en", () => {
+      const { container } = render({ value: 0 })
+      expect(container.firstElementChild!.textContent).toBe("0.00");
+      expect(container.firstElementChild!.classList).not.toContain("text-signal-success");
+      expect(container.firstElementChild!.classList).not.toContain("text-signal-error");
+    });
+
+    it("es", () => {
+      const { container } = render({ value: 0, locale: "es" });
+      expect(container.firstElementChild!.textContent).toBe("0,00");
+    });
+
+    it("fr", () => {
+      const { container } = render({ value: 0, locale: "fr" });
+      expect(container.firstElementChild!.textContent).toBe("0,00");
+    });
+
+    it("zh", () => {
+      const { container } = render({ value: 0, locale: "zh" });
+      expect(container.firstElementChild!.textContent).toBe("0.00");
+    });
+  });
+
+  describe("should display positive value correctly", () => {
+    it("en", () => {
+      const { container } = render({ value: 21000001.23456789 });
+      expect(container.firstElementChild!.textContent).toBe("+21,000,001.23456789");
+      expect(container.firstElementChild!.classList).toContain("text-signal-success");
+      expect(container.firstElementChild!.classList).not.toContain("text-signal-error");
+    });
+
+    it("es", () => {
+      const { container } = render({ value: 21000001.23456789, locale: "es" });
+      expect(container.firstElementChild!.textContent).toBe("+21.000.001,23456789");
+    });
+
+    it("fr", () => {
+      const { container } = render({ value: 21000001.23456789, locale: "fr" });
+      expect(container.firstElementChild!.textContent).toBe("+21 000 001,23456789");
+    });
+
+    it("zh", () => {
+      const { container } = render({ value: 21000001.23456789, locale: "zh" });
+      expect(container.firstElementChild!.textContent).toBe("+21,000,001.23456789");
+    });
+  });
+
+  describe("should display negative value correctly", () => {
+    it("en", () => {
+      const { container } = render({ value: -1337.42 });
+      expect(container.firstElementChild!.textContent).toBe("-1,337.42");
+      expect(container.firstElementChild!.classList).not.toContain("text-signal-success");
+      expect(container.firstElementChild!.classList).toContain("text-signal-error");
+    });
+
+    it("es", () => {
+      const { container } = render({ value: -1337.42, locale: "es" });
+      expect(container.firstElementChild!.textContent).toBe("-1337,42");
+    });
+
+    it("fr", () => {
+      const { container } = render({ value: -1337.42, locale: "fr" });
+      expect(container.firstElementChild!.textContent).toBe("-1 337,42");
+    });
+
+    it("zh", () => {
+      const { container } = render({ value: -1337.42, locale: "zh" });
+      expect(container.firstElementChild!.textContent).toBe("-1,337.42");
+    });
+  });
+});

--- a/src/components/FormattedCurrency.test.tsx
+++ b/src/components/FormattedCurrency.test.tsx
@@ -117,4 +117,17 @@ describe("FormattedCurrency", () => {
       expect(container.firstElementChild!.classList).toContain("text-text-300");
     });
   });
+
+  describe("sign display", () => {
+    it("should verify disabling sign", () => {
+      const { container } = render({ value: 21, signDisplay: "never" });
+      expect(container.firstElementChild!.textContent).toBe("21.00");
+    });
+    
+    it("should verify adding sign to zero", () => {
+      const { container } = render({ value: 0, signDisplay: "always"});
+      expect(container.firstElementChild!.textContent).toBe("+0.00");
+    });
+  });
+
 });

--- a/src/components/FormattedCurrency.test.tsx
+++ b/src/components/FormattedCurrency.test.tsx
@@ -104,17 +104,23 @@ describe("FormattedCurrency", () => {
       expect(container.firstElementChild!.classList).not.toContain("text-signal-error");
     });
 
-    it("should verify adapting font color", () => {
-      const { container } = render({ value: 21, color: "red" });
-      expect(container.firstElementChild!.classList).not.toContain("text-signal-success");
-      expect(container.firstElementChild!.classList).toContain("text-signal-error");
-    });
-
     it("should verify customizing font color", () => {
       const { container } = render({ value: 21, color: "none", className: "text-text-300" });
       expect(container.firstElementChild!.classList).not.toContain("text-signal-success");
       expect(container.firstElementChild!.classList).not.toContain("text-signal-error");
       expect(container.firstElementChild!.classList).toContain("text-text-300");
+    });
+
+    it("should verify displaying positive value as debit", () => {
+      const { container } = render({ value: 21, type: "debit" });
+      expect(container.firstElementChild!.classList).not.toContain("text-signal-success");
+      expect(container.firstElementChild!.classList).toContain("text-signal-error");
+    });
+
+    it("should verify displaying negative value as credit", () => {
+      const { container } = render({ value: -21, type: "credit" });
+      expect(container.firstElementChild!.classList).toContain("text-signal-success");
+      expect(container.firstElementChild!.classList).not.toContain("text-signal-error");
     });
   });
 
@@ -123,7 +129,7 @@ describe("FormattedCurrency", () => {
       const { container } = render({ value: 21, signDisplay: "never" });
       expect(container.firstElementChild!.textContent).toBe("21.00");
     });
-    
+
     it("should verify adding sign to zero", () => {
       const { container } = render({ value: 0, signDisplay: "always"});
       expect(container.firstElementChild!.textContent).toBe("+0.00");

--- a/src/components/FormattedCurrency.test.tsx
+++ b/src/components/FormattedCurrency.test.tsx
@@ -79,6 +79,34 @@ describe("FormattedCurrency", () => {
     });
   });
 
+  describe("currency", () => {
+    it("should verify dollar sign can be disabled", () => {
+      const { container } = render({ value: 21, currency: "USD" });
+      expect(container.firstElementChild!.textContent).toBe("+$21.00");
+    });
+    it("should verify dollar sign can be disabled (es)", () => {
+      const { container } = render({ value: 21, currency: "USD", locale: "es" });
+      expect(container.firstElementChild!.textContent).toBe("+21,00 US$");
+    });
+    it("should verify euro sign can be disabled (fr)", () => {
+      const { container } = render({ value: 21, currency: "EUR", locale: "fr" });
+      expect(container.firstElementChild!.textContent).toBe("+21,00 €");
+    });
+    it("should verify euro sign can be disabled (zh)", () => {
+      const { container } = render({ value: 21, currency: "EUR", locale: "zh"});
+      expect(container.firstElementChild!.textContent).toBe("+€21.00");
+    });
+    it("should verify euro sign can be disabled (pt)", () => {
+      const { container } = render({ value: 21, currency: "EUR", locale: "pt"});
+      expect(container.firstElementChild!.textContent).toBe("+€ 21,00");
+    });
+    it("should verify bitcoin sign can be disabled", () => {
+      const { container } = render({ value: 21, currency: "BTC" });
+      expect(container.firstElementChild!.textContent).toBe("+BTC 21.00")
+      // TODO: should be `expect(container.firstElementChild!.textContent).toBe("+₿21.00")`
+    });
+  });
+
   describe("font color", () => {
     it("should verify zero value color", () => {
       const { container } = render({ value: 0 });

--- a/src/components/FormattedCurrency.tsx
+++ b/src/components/FormattedCurrency.tsx
@@ -6,18 +6,23 @@ export type FormattedCurrencyProps = {
   className?: string,
   color?: "auto" | "none",
   type?: "auto" | "credit" | "debit",
-} & Pick<FormatNumberOptions, 'signDisplay'>
+} & Pick<FormatNumberOptions, 'signDisplay' | 'currency' | 'currencyDisplay'>
 
-const FormattedCurrency = ({ value, className, color = "auto", type = "auto", signDisplay = "exceptZero" } : FormattedCurrencyProps) => {
+const FormattedCurrency = ({ value, className, color = "auto", type = "auto", currency, currencyDisplay = "symbol", signDisplay = "exceptZero" } : FormattedCurrencyProps) => {
   return (
     <span className={cn(className, {
         "text-signal-success": color !== "none" && (type === "credit" || (type === "auto" && value > 0)),
         "text-signal-error": color !== "none" && (type === "debit" || (type === "auto" && value < 0)),
       })}>
-      <FormattedNumber value={value} 
+      <FormattedNumber
+        value={value}
         signDisplay={signDisplay}
         minimumFractionDigits={2}
-        maximumFractionDigits={8} />
+        maximumFractionDigits={8}
+        style={currency !== undefined ? "currency" : "decimal"}
+        currency={currency}
+        currencyDisplay={currency !== undefined ? currencyDisplay : undefined}
+      />
     </span>
   )
 };

--- a/src/components/FormattedCurrency.tsx
+++ b/src/components/FormattedCurrency.tsx
@@ -4,14 +4,15 @@ import { cn } from "@/lib/utils";
 export type FormattedCurrencyProps = {
   value: number,
   className?: string,
-  color?: "auto" | "red" | "green" | "none",
+  color?: "auto" | "none",
+  type?: "auto" | "credit" | "debit",
 } & Pick<FormatNumberOptions, 'signDisplay'>
 
-const FormattedCurrency = ({ value, className, color = "auto", signDisplay = "exceptZero" } : FormattedCurrencyProps) => {
+const FormattedCurrency = ({ value, className, color = "auto", type = "auto", signDisplay = "exceptZero" } : FormattedCurrencyProps) => {
   return (
     <span className={cn(className, {
-        "text-signal-success": color === "green" || (color === "auto" && value > 0),
-        "text-signal-error": color === "red" || (color === "auto" && value < 0),
+        "text-signal-success": color !== "none" && (type === "credit" || (type === "auto" && value > 0)),
+        "text-signal-error": color !== "none" && (type === "debit" || (type === "auto" && value < 0)),
       })}>
       <FormattedNumber value={value} 
         signDisplay={signDisplay}

--- a/src/components/FormattedCurrency.tsx
+++ b/src/components/FormattedCurrency.tsx
@@ -1,20 +1,20 @@
-import { FormattedNumber } from "react-intl";
+import { FormattedNumber, type FormatNumberOptions } from "react-intl";
 import { cn } from "@/lib/utils";
 
 export type FormattedCurrencyProps = {
   value: number,
   className?: string,
   color?: "auto" | "red" | "green" | "none",
-};
+} & Pick<FormatNumberOptions, 'signDisplay'>
 
-const FormattedCurrency = ({ value, className, color = "auto" } : FormattedCurrencyProps) => {
+const FormattedCurrency = ({ value, className, color = "auto", signDisplay = "exceptZero" } : FormattedCurrencyProps) => {
   return (
     <span className={cn(className, {
         "text-signal-success": color === "green" || (color === "auto" && value > 0),
         "text-signal-error": color === "red" || (color === "auto" && value < 0),
       })}>
       <FormattedNumber value={value} 
-        signDisplay="exceptZero"
+        signDisplay={signDisplay}
         minimumFractionDigits={2}
         maximumFractionDigits={8} />
     </span>

--- a/src/components/FormattedCurrency.tsx
+++ b/src/components/FormattedCurrency.tsx
@@ -4,13 +4,14 @@ import { cn } from "@/lib/utils";
 export type FormattedCurrencyProps = {
   value: number,
   className?: string,
+  color?: "auto" | "red" | "green" | "none",
 };
 
-const FormattedCurrency = ({ value, className } : FormattedCurrencyProps) => {
+const FormattedCurrency = ({ value, className, color = "auto" } : FormattedCurrencyProps) => {
   return (
     <span className={cn(className, {
-        "text-signal-success": value > 0,
-        "text-signal-error": value < 0,
+        "text-signal-success": color === "green" || (color === "auto" && value > 0),
+        "text-signal-error": color === "red" || (color === "auto" && value < 0),
       })}>
       <FormattedNumber value={value} 
         signDisplay="exceptZero"

--- a/src/components/FormattedCurrency.tsx
+++ b/src/components/FormattedCurrency.tsx
@@ -1,12 +1,16 @@
 import { FormattedNumber, type FormatNumberOptions } from "react-intl";
 import { cn } from "@/lib/utils";
 
+const BITCOIN_CODE = "BTC";
+const BITCOIN_NAME = "bitcoin";
+const BITCOIN_SYMBOL = "₿";
+
 export type FormattedCurrencyProps = {
   value: number,
   className?: string,
   color?: "auto" | "none",
   type?: "auto" | "credit" | "debit",
-  currency?: FormatNumberOptions['currency'] | "BTC"
+  currency?: FormatNumberOptions['currency'] | typeof BITCOIN_CODE
 } & Pick<FormatNumberOptions, 'signDisplay' | 'currencyDisplay'>
 
 const FormattedCurrency = ({ value, className, color = "auto", type = "auto", currency, currencyDisplay = "symbol", signDisplay = "exceptZero" } : FormattedCurrencyProps) => {
@@ -18,12 +22,23 @@ const FormattedCurrency = ({ value, className, color = "auto", type = "auto", cu
       <FormattedNumber
         value={value}
         signDisplay={signDisplay}
-        minimumFractionDigits={currency === "BTC" ? 8 : 2}
+        minimumFractionDigits={currency === BITCOIN_CODE ? 8 : 2}
         maximumFractionDigits={8}
         style={currency !== undefined ? "currency" : "decimal"}
         currency={currency}
         currencyDisplay={currency !== undefined ? currencyDisplay : undefined}
-      />
+      >
+        {(formattedNumber: string) => {
+          if (currency !== BITCOIN_CODE) {
+            return <>{formattedNumber}</>;
+          }
+          switch(currencyDisplay) {
+            case "name": return <>{formattedNumber.replace(BITCOIN_CODE, BITCOIN_NAME)}</>; 
+            case "symbol": return <>{formattedNumber.replace(BITCOIN_CODE, BITCOIN_SYMBOL)}</>;
+            default: return <>{formattedNumber}</>;
+          }
+        }}
+      </FormattedNumber>
     </span>
   )
 };

--- a/src/components/FormattedCurrency.tsx
+++ b/src/components/FormattedCurrency.tsx
@@ -1,0 +1,25 @@
+import { FormattedNumber } from "react-intl";
+import { cn } from "@/lib/utils";
+
+export type FormattedCurrencyProps = {
+  value: number,
+  className?: string,
+};
+
+const FormattedCurrency = ({ value, className } : FormattedCurrencyProps) => {
+  return (
+    <span className={cn(className, {
+        "text-signal-success": value > 0,
+        "text-signal-error": value < 0,
+      })}>
+      <FormattedNumber value={value} 
+        signDisplay="exceptZero"
+        minimumFractionDigits={2}
+        maximumFractionDigits={8} />
+    </span>
+  )
+};
+
+FormattedCurrency.displayName = "FormattedCurrency";
+
+export { FormattedCurrency };

--- a/src/components/FormattedCurrency.tsx
+++ b/src/components/FormattedCurrency.tsx
@@ -6,7 +6,8 @@ export type FormattedCurrencyProps = {
   className?: string,
   color?: "auto" | "none",
   type?: "auto" | "credit" | "debit",
-} & Pick<FormatNumberOptions, 'signDisplay' | 'currency' | 'currencyDisplay'>
+  currency?: FormatNumberOptions['currency'] | "BTC"
+} & Pick<FormatNumberOptions, 'signDisplay' | 'currencyDisplay'>
 
 const FormattedCurrency = ({ value, className, color = "auto", type = "auto", currency, currencyDisplay = "symbol", signDisplay = "exceptZero" } : FormattedCurrencyProps) => {
   return (
@@ -17,7 +18,7 @@ const FormattedCurrency = ({ value, className, color = "auto", type = "auto", cu
       <FormattedNumber
         value={value}
         signDisplay={signDisplay}
-        minimumFractionDigits={2}
+        minimumFractionDigits={currency === "BTC" ? 8 : 2}
         maximumFractionDigits={8}
         style={currency !== undefined ? "currency" : "decimal"}
         currency={currency}

--- a/src/pages/Bills.tsx
+++ b/src/pages/Bills.tsx
@@ -1,7 +1,8 @@
-import { FormattedMessage, FormattedNumber } from "react-intl";
+import { FormattedMessage } from "react-intl";
 import { CalendarDaysIcon, ChevronsUpDownIcon, SearchIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import createBillIllustration from "@/assets/create-bill-illustration.svg";
+import { FormattedCurrency } from "@/components/FormattedCurrency";
 
 export function Bills() {
   return (
@@ -94,9 +95,7 @@ export function Bills() {
                 <div className="flex justify-between">
                   <span className="text-sm text-text-200">12-Nov-24</span>
                   <div className="flex gap-1 items-baseline">
-                    <span className="text-sm text-signal-success">
-                      <FormattedNumber value={12.49002} signDisplay="always" minimumFractionDigits={2} maximumFractionDigits={8} />
-                    </span>
+                    <FormattedCurrency value={12.49002} className="text-sm" />
                     <span className="text-xs text-text-300">USD</span>
                   </div>
                 </div>
@@ -110,9 +109,7 @@ export function Bills() {
                 <div className="flex justify-between">
                   <span className="text-sm text-text-200">12-Nov-24</span>
                   <div className="flex gap-1 items-baseline">
-                    <span className="text-sm text-signal-success">
-                      <FormattedNumber value={3234.12001} signDisplay="always" minimumFractionDigits={2} maximumFractionDigits={8} />
-                    </span>
+                    <FormattedCurrency value={3234.12001} className="text-sm" />
                     <span className="text-xs text-text-300">USD</span>
                   </div>
                 </div>
@@ -126,9 +123,7 @@ export function Bills() {
                 <div className="flex justify-between">
                   <span className="text-sm text-text-200">10-Nov-24</span>
                   <div className="flex gap-1 items-baseline">
-                    <span className="text-sm text-signal-error">
-                      <FormattedNumber value={-2.49002} signDisplay="always" minimumFractionDigits={2} maximumFractionDigits={8} />
-                    </span>
+                    <FormattedCurrency value={-2.49002} className="text-sm" />
                     <span className="text-xs text-text-300">USD</span>
                   </div>
                 </div>

--- a/src/pages/Bills.tsx
+++ b/src/pages/Bills.tsx
@@ -1,4 +1,4 @@
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, FormattedNumber } from "react-intl";
 import { CalendarDaysIcon, ChevronsUpDownIcon, SearchIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import createBillIllustration from "@/assets/create-bill-illustration.svg";
@@ -95,7 +95,7 @@ export function Bills() {
                   <span className="text-sm text-text-200">12-Nov-24</span>
                   <div className="flex gap-1 items-baseline">
                     <span className="text-sm text-signal-success">
-                      +12.49002
+                      <FormattedNumber value={12.49002} signDisplay="always" minimumFractionDigits={2} maximumFractionDigits={8} />
                     </span>
                     <span className="text-xs text-text-300">USD</span>
                   </div>
@@ -111,7 +111,7 @@ export function Bills() {
                   <span className="text-sm text-text-200">12-Nov-24</span>
                   <div className="flex gap-1 items-baseline">
                     <span className="text-sm text-signal-success">
-                      +3234.12001
+                      <FormattedNumber value={3234.12001} signDisplay="always" minimumFractionDigits={2} maximumFractionDigits={8} />
                     </span>
                     <span className="text-xs text-text-300">USD</span>
                   </div>
@@ -126,7 +126,9 @@ export function Bills() {
                 <div className="flex justify-between">
                   <span className="text-sm text-text-200">10-Nov-24</span>
                   <div className="flex gap-1 items-baseline">
-                    <span className="text-sm text-signal-error">-2.49002</span>
+                    <span className="text-sm text-signal-error">
+                      <FormattedNumber value={-2.49002} signDisplay="always" minimumFractionDigits={2} maximumFractionDigits={8} />
+                    </span>
                     <span className="text-xs text-text-300">USD</span>
                   </div>
                 </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   assetsInclude: ["**/*.woff2"],
   test: {
     environment: "jsdom",
-    include: ["src/__tests__/**/*.test.{ts,tsx}"],
+    include: ["**/*.test.{ts,tsx}"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "lcov"],


### PR DESCRIPTION
Fixes #69.

This adds a rudimentary base component `FormattedCurrency` that can be extended in the future.
This components renders currency values according to the users locale. 

Currently only applied on the Bills page.