### PR TITLE
ci: update and improve ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run tests and generate coverage
         run: npm run test -- --coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Run tests and generate coverage
         run: npm run test -- --coverage
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Run tests and generate coverage
         run: npm run test -- --coverage
 
+      - name: Build
+        run: npm run build
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,18 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['v22.11.0']
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+      - name: Set up Node.js (${{ matrix.node-version }})
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION

Small adaptions to the ci workflow:
- update dependencies to prevent warning:
```
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/setup-node@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```
- update node version from v18 to the latest LTS release v22.11.0
- install dependencies with [`npm ci` instead of `npm install`](https://docs.npmjs.com/cli/v10/commands/npm-ci#description)
- run linter with `npm run lint`
- build app with `npm run build`