### PR TITLE
chore(lint): apply storybook eslint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import storybook from 'eslint-plugin-storybook'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
@@ -17,6 +18,12 @@ export default tseslint.config(
       ...tseslint.configs.recommended,
     ],
     files: ['**/*.test.{ts,tsx}'],
+  },
+  {
+    extends: [
+      ...storybook.configs['flat/recommended'],
+    ],
+    files: ['**/*.stories.{ts,tsx}'],
   },
   {
     extends: [

--- a/package.json
+++ b/package.json
@@ -71,10 +71,5 @@
     "typescript-eslint": "^8.15.0",
     "vite": "^5.4.11",
     "vitest": "^2.1.5"
-  },
-  "eslintConfig": {
-    "extends": [
-      "plugin:storybook/recommended"
-    ]
   }
 }


### PR DESCRIPTION
## 📝 Description

Before this commit the storybook eslint rules have not been applied.
After this commit, story files will be linted.

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. checkout branch
2. create a rule violation in a story file, e.g.
```patch
diff --git a/src/stories/Button.stories.ts b/src/stories/Button.stories.ts
index 2a05e01..200516e 100644
--- a/src/stories/Button.stories.ts
+++ b/src/stories/Button.stories.ts
@@ -21,7 +21,7 @@ const meta = {
   args: { onClick: fn() },
 } satisfies Meta<typeof Button>;
 
-export default meta;
+export { meta };
 type Story = StoryObj<typeof meta>;
 
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
```
3. run `npm run lint` and verify lint errors

---

## 📄 Relevant Documentation

See the `eslint-plugin-storybook` readme regarding the eslint flat config: https://github.com/storybookjs/eslint-plugin-storybook?tab=readme-ov-file#configuration-eslintconfigcmjs 
