### PR TITLE
chore(ci): update codecov action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}  # Required if the repo is private
           files: ./coverage/lcov.info           # Path to the lcov report


### PR DESCRIPTION
Updates `codecov-action` from v4 to v5.

This should resolve an issue with tokenless uploads for external contributions.

See: https://github.com/codecov/codecov-action/pull/1688 (included in [v5.0.6](https://github.com/codecov/codecov-action/releases/tag/v5.0.6))