### PR TITLE
chore: dev disable in context tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "VITE_BITCR_DEV_INCLUDE_CROWIN_IN_CONTEXT_TOOLING=false vite",
     "dev:build": "NODE_ENV=development npm run build -- --mode development",
     "build": "tsc -b && vite build",
     "lint": "eslint . --max-warnings=0",

--- a/src/pages/contacts/Overview.tsx
+++ b/src/pages/contacts/Overview.tsx
@@ -68,9 +68,7 @@ export default function Overview() {
 
         <Search
           placeholder="Name, address, email..."
-          onSearch={(e) => {
-            console.log(e);
-          }}
+          onSearch={() => {}}
         />
       </div>
 


### PR DESCRIPTION
Do not enable crowdin in-context tooling while developing locally.
Also fixed a type error on contacts overview page.
