### PR TITLE
chore(Input): add input storybook

### DIFF
--- a/src/components/ui/input.stories.tsx
+++ b/src/components/ui/input.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta,  StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { CalendarIcon } from 'lucide-react';
+import { Input } from './input';
+
+const meta = {
+  title: 'Components/Input',
+  component: Input,
+  args: { onClick: fn() },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    type: 'text',
+    label: 'Label',
+    required: false,
+    disabled: false,
+  }
+};
+
+export const Styled: Story = {
+  args: {
+    ...Default.args,
+    required: true,
+    clearable: true,
+    hint: 'Hint',
+    icon: <CalendarIcon className="w-5 h-5" strokeWidth={1} />,
+  }
+};
+
+export const Variants: Story = {
+  args: {
+  ...Default.args,
+    hint: 'Hint',
+  },
+  render: (args) => (
+    <div className="flex flex-col gap-2">
+      <Input {...args} required />
+      <Input {...args} required icon={<CalendarIcon className="w-5 h-5" strokeWidth={1} />} />
+      <Input {...args} value="Content" required clearable />
+      <Input {...args} value="Content" required clearable icon={<CalendarIcon className="w-5 h-5" strokeWidth={1} />}/>
+      <Input {...args} value="Content" disabled icon={<CalendarIcon className="w-5 h-5" strokeWidth={1} />}/>
+
+    </div>
+  ),
+};
+
+
+export const InputSizes: Story = {
+  args: {
+  ...Styled.args,
+  },
+  render: (args) => (
+    <div className="flex flex-col gap-2">
+      <Input {...args} label="sm" inputSize="sm" />
+      <Input {...args} label="md" inputSize="md" />
+      <Input {...args} label="lg  " inputSize="lg" />
+    </div>
+  ),
+};
+
+export const StateColors: Story = {
+  args: {
+  ...Styled.args,
+  },
+  render: (args) => (
+    <div className="flex flex-col gap-2">
+      <Input {...args} label="Default"/>
+      <Input {...args} label="Success" success />
+      <Input {...args} label="Error" error />
+    </div>
+  ),
+};


### PR DESCRIPTION
## 📝 Description

Adds storybook stories for `Input` component. This is a follow-up to #121.

Relates to #76, #121


---

## 📸 Screenshots/Screen record (if applicable)

If your changes include UI updates, please add before and after screenshots/screen records:

![image](https://github.com/user-attachments/assets/244ef850-e9b9-4d46-9999-91d4b7acbe6e)

## 🚀 Changes Made

- **Other Changes:**
  - add storybook for `Input` component

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Run `npm run storybook`
2. Navigate to http://localhost:6006/?path=/story/components-input--variants

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #76
- #121

## 📄 Relevant Documentation (optional)

Provide links to relevant documentation that reviewers may need:

- https://www.figma.com/design/XqVOGOoS8tZhGK5ROmqGFv/Open-tasks?node-id=131-746&node-type=frame&m=dev
