### PR TITLE
test(LanguageProvider): don't fail on newly added languages

### DIFF
--- a/src/context/language/LanguageProvider.test.tsx
+++ b/src/context/language/LanguageProvider.test.tsx
@@ -37,28 +37,28 @@ describe("LanguageProvider", () => {
       mockNavigation({ language: "en-US" });
 
       const { container } = render({});
-      expect(container.textContent).toBe("en-US");
+      expect(container).toHaveTextContent("en-US");
     });
 
     it("es", () => {
       mockNavigation({ language: "es-ES" });
 
       const { container } = render({});
-      expect(container.textContent).toBe("es-ES");
+      expect(container).toHaveTextContent("es-ES");
     });
 
     it("fr", () => {
       mockNavigation({ language: "fr-FR" });
 
       const { container } = render({});
-      expect(container.textContent).toBe("fr-FR");
+      expect(container).toHaveTextContent("fr-FR");
     });
 
     it("zh", () => {
       mockNavigation({ language: "zh-CN" });
 
       const { container } = render({});
-      expect(container.textContent).toBe("zh-CN");
+      expect(container).toHaveTextContent("zh-CN");
     });
   });
 
@@ -76,11 +76,11 @@ describe("LanguageProvider", () => {
         }
       });
 
-      expect(container.textContent).toBe("en-US");
+      expect(container).toHaveTextContent("en-US");
 
       await vi.runAllTimersAsync();
 
-      expect(container.textContent).toBe("it-IT");
+      expect(container).toHaveTextContent("it-IT");
     });
   });
 
@@ -97,7 +97,10 @@ describe("LanguageProvider", () => {
 
       await vi.runAllTimersAsync();
 
-      expect(availableLocales).toMatchObject([ 'ach-UG', 'en-US', 'es-AR', 'tr-TR' ]);
+      expect(availableLocales).toContain('ach-UG');
+      expect(availableLocales).toContain('en-US');
+      expect(availableLocales).toContain('es-AR');
+      expect(availableLocales).toContain('tr-TR');
     });
   });
 


### PR DESCRIPTION
Before this PR, tests failed when a new language is added.
After this PR, the tests are more lenient when a new language is added.