### PR TITLE
fix(style): fix container background color issue

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -30,11 +30,14 @@ body {
   margin: 0;
   padding: 0;
   display: flex;
-  align-items: center;
   place-items: center;
   justify-content: center;
   min-width: 100vw;
   min-height: 100vh;
+}
+
+#root {
+  overflow: auto;
 }
 
 @media (prefers-color-scheme: light) {
@@ -101,7 +104,7 @@ body {
   * {
     @apply border-border;
   }
-  body {
+  #root {
     @apply bg-background text-foreground;
   }
 }


### PR DESCRIPTION
Relates to #22.

Attempt to fix the container background color issue for content below the fold.

Info: 
- Removes the background for `body`.
- This does not fix the overlay issue of the fixed bottom navigation bar.

@cryptosalomao Can you tell me if this is a favorable approach? :pray: 

## 📸 Screenshots/Screen record (if applicable)

If your changes include UI updates, please add before and after screenshots/screen records:

**Before:**
<img src="https://github.com/user-attachments/assets/52f5ebdd-4928-4441-a8df-a19a5fa504c8" width=250 />


**After:**
<img src="https://github.com/user-attachments/assets/9a5f56fb-9a75-40be-ab68-e80c8ac68d8a" width=250 />

