### PR TITLE
fix: import.meta can only be only appear in a module

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "VITE_BITCR_API_MOCK_ENABLE=true vite",
     "build": "tsc -b && vite build",
     "build:dev": "NODE_ENV=development npm run build -- --mode development",
     "build:crowdin": "VITE_BITCR_DEV_INCLUDE_CROWDIN_IN_CONTEXT_TOOLING=true npm run build:dev",

--- a/src/constants/meta.ts
+++ b/src/constants/meta.ts
@@ -1,0 +1,5 @@
+
+export default {
+  devModeEnabled: import.meta.env.DEV,
+  apiMocksEnabled: import.meta.env.VITE_BITCR_API_MOCK_ENABLE === "true",
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,7 +18,8 @@ import Login from "./pages/Login";
 import RecoverWithSeedPhrase from "./pages/RecoverWithSeedPhrase";
 import Home from "./pages/home";
 import { Notifications, NotificationsEmpty } from "./pages/Notifications";
-import routes from "./constants/routes";
+import routes from "@/constants/routes";
+import meta from "@/constants/meta";
 
 import "./index.css";
 import "./styles/fonts.css";
@@ -307,7 +308,7 @@ const router = createBrowserRouter(
 );
 
 const prepare = async () => {
-  if (import.meta.env.DEV) {
+  if (meta.devModeEnabled) {
     const flatten = (it: RouteObject) =>
       it.children === undefined
         ? it
@@ -327,7 +328,9 @@ const prepare = async () => {
         .flatMap((it) => flatten(it))
         .map((it) => [it.path, location.origin + (it.path || "")])
     );
+  }
 
+  if (meta.apiMocksEnabled) {
     const { worker } = await import("./mocks/browser");
     await worker.start();
   }

--- a/src/pages/contacts/Overview.tsx
+++ b/src/pages/contacts/Overview.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import Search from "@/components/ui/search";
 import { Separator } from "@/components/ui/separator";
 import routes from "@/constants/routes";
+import meta from "@/constants/meta";
 
 import List from "./components/List";
 import EmptyList from "./components/EmptyList";
@@ -135,7 +136,7 @@ export default function Overview() {
 
   return (
     <Page className="gap-6" displayBottomNavigation>
-      {import.meta.env.DEV && (
+      {meta.devModeEnabled && (
         <>
           <Button
             size="xxs"


### PR DESCRIPTION
`import.meta` can only be only appear in a module, i.e. it cannot be used in main.tsx during development.
As a workaround, export constants accessing `import.meta` in a distinct file.