### PR TITLE
feat: add docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.github/
+Dockerfile
+.dockerignore
+/*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+
+FROM node:22.11.0-slim@sha256:f035ba7ffee18f67200e2eb8018e0f13c954ec16338f264940f701997e3c12da AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install --no-fund --no-audit
+
+COPY . .
+
+RUN npm run build
+
+FROM nginx:1.27.4-alpine@sha256:4ff102c5d78d254a6f0da062b3cf39eaf07f01eec0927fd21e219d0af8bc0591
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+COPY docker/nginx/snippets/proxy-params.conf /etc/nginx/snippets/proxy-params.conf
+# each time nginx is started it will perform variable substition in all template
+# files found in `/etc/nginx/templates/*.template`, and copy the results (without
+# the `.template` suffix) into `/etc/nginx/conf.d/`.
+COPY docker/nginx/templates/default.conf.template /etc/nginx/templates/default.conf.template
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+
+services:
+  app:
+    build: .
+    ports:
+      - "8080:80"

--- a/docker/nginx/snippets/proxy-params.conf
+++ b/docker/nginx/snippets/proxy-params.conf
@@ -1,0 +1,5 @@
+proxy_redirect off;
+proxy_set_header Host $http_host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto http;

--- a/docker/nginx/templates/default.conf.template
+++ b/docker/nginx/templates/default.conf.template
@@ -1,3 +1,39 @@
+charset utf-8;
+
+tcp_nodelay on;
+
+gzip on;
+gzip_comp_level 3; # Default value is 1
+gzip_types
+  application/atom+xml
+  application/javascript
+  application/json
+  application/ld+json
+  application/manifest+json
+  application/rss+xml
+  application/vnd.geo+json
+  application/vnd.ms-fontobject
+  application/x-font-ttf
+  application/x-javascript
+  application/x-web-app-manifest+json
+  application/xhtml+xml
+  application/xml
+  font/opentype
+  font/truetype
+  image/bmp
+  image/svg+xml
+  image/x-icon
+  text/html
+  text/cache-manifest
+  text/css
+  text/javascript
+  text/plain
+  text/vcard
+  text/vnd.rim.location.xloc
+  text/vtt
+  text/x-component
+  text/x-cross-domain-policy
+  text/xml;
 
 server {
     listen 80;
@@ -5,9 +41,6 @@ server {
 
     root /usr/share/nginx/html;
     index index.html;
-
-    gzip on;
-    gzip_types text/plain text/xml text/css application/javascript application/json image/svg+xml;
 
     location / {
         include /etc/nginx/snippets/proxy-params.conf;

--- a/docker/nginx/templates/default.conf.template
+++ b/docker/nginx/templates/default.conf.template
@@ -1,0 +1,33 @@
+
+server {
+    listen 80;
+    listen [::]:80;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/xml text/css application/javascript application/json image/svg+xml;
+
+    location / {
+        include /etc/nginx/snippets/proxy-params.conf;
+
+        try_files $uri $uri/ $uri.html /index.html;
+        add_header Cache-Control "no-store";
+    }
+
+    location ~* \.(?:json)$ {
+        expires 1d;
+        add_header Cache-Control "public";
+    }
+
+    location ~* \.(?:css|js|jpg|svg|png)$ {
+        expires 90d;
+        add_header Cache-Control "public";
+    }
+
+    location ~* \.(?:woff2)$ {
+        expires 180d;
+        add_header Cache-Control "public";
+    }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "i18n-extract": "formatjs extract 'src/**/*.{ts,tsx}' --ignore='**/*.d.ts' --out-file './src/i18n/source.json' --id-interpolation-pattern '[sha512:contenthash:base64:6]' --format simple",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
-    "prepare": "husky"
+    "prepare": "husky",
+    "docker:build": "docker build --tag wildcat-dashboard-ui .",
+    "docker:rebuild": "npm run docker:build -- --no-cache",
+    "docker:up": "docker compose up"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
Adds `Dockerfile` and `docker-compose.yml` files.
After this commit is applied, the app can be easily included in a large setup (e.g. regtest env with actual instances).

## Test

Build docker image:
```shell
npm run docker:build
# or `npm run docker:rebuild` to rebuild from scratch
```

Run docker image (via `docker compose`):
```shell
npm run docker:up
```